### PR TITLE
手动切换 window.rootViewController 后移除节点会出现节点不一致

### DIFF
--- a/ios/Classes/Stack/DNavigator.m
+++ b/ios/Classes/Stack/DNavigator.m
@@ -453,7 +453,7 @@ UIViewController *_DStackCurrentController(UIViewController *controller)
     if ([self isCustomClass]) {
         if (![self.dStackFlutterNodeMessage boolValue]) {
             UIViewController *dismiss = _DStackCurrentController(self);
-            if (!dismiss.isGesturePoped && [dismiss isCustomClass]) {
+            if (!dismiss.isGesturePoped && [dismiss isCustomClass] && dismiss.presentingViewController != nil) {
                 // 不是手势触发的dismiss
                 [[DStackNavigator instance] willAppearViewController:dismiss.presentingViewController];
                 checkNode(dismiss, DNodeActionTypeDismiss);


### PR DESCRIPTION
项目启动后，手动切换当前 window 根控制器会触发 d_stackDismissViewControllerAnimated；
由于页面通过根控制器来显示，并不是present，所以节点未入栈；
并且切换 rootViewController 会触发 dismiss，导致后续执行 checkRemovedNode 移除节点时产生问题；